### PR TITLE
Handle localStorage write failures for theme persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,13 @@ export default function App() {
     if (typeof document === "undefined") return;
     document.documentElement.classList.toggle("dark", theme === "dark");
     document.documentElement.style.colorScheme = theme;
-    window.localStorage.setItem("theme", theme);
+    try {
+      window.localStorage.setItem("theme", theme);
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn("Failed to persist theme preference", error);
+      }
+    }
   }, [theme]);
 
   const toggleTheme = useCallback(() => {


### PR DESCRIPTION
## Summary
- wrap theme persistence in App with try/catch to avoid crashing in storage-restricted contexts
- log a warning in development when localStorage writes fail so toggling continues to function

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19a397d88832ab4474baa102d9c64