### PR TITLE
Style MarkdownSmith preview content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@tailwindcss/typography": "^0.5.15",
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
@@ -1817,6 +1818,33 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
+    "@tailwindcss/typography": "^0.5.15",
     "@vitejs/plugin-react": "^5.0.4",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,81 @@
+import typography from "@tailwindcss/typography";
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
-    extend: {},
+    extend: {
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            maxWidth: "none",
+            color: theme("colors.slate.700"),
+            a: {
+              color: theme("colors.cyan.600"),
+              fontWeight: theme("fontWeight.semibold"),
+              textDecoration: "none",
+              '&:hover': {
+                color: theme("colors.cyan.500"),
+                textDecoration: "underline",
+              },
+            },
+            h1: {
+              fontWeight: theme("fontWeight.extrabold"),
+              color: theme("colors.slate.900"),
+            },
+            h2: {
+              fontWeight: theme("fontWeight.bold"),
+              color: theme("colors.slate.900"),
+            },
+            h3: {
+              fontWeight: theme("fontWeight.semibold"),
+              color: theme("colors.slate.900"),
+            },
+            strong: {
+              color: theme("colors.slate.900"),
+            },
+            code: {
+              color: theme("colors.cyan.700"),
+              fontWeight: theme("fontWeight.medium"),
+            },
+            'blockquote p:first-of-type::before': { display: "none" },
+            'blockquote p:last-of-type::after': { display: "none" },
+          },
+        },
+        invert: {
+          css: {
+            color: theme("colors.slate.200"),
+            a: {
+              color: theme("colors.cyan.300"),
+              '&:hover': {
+                color: theme("colors.cyan.200"),
+              },
+            },
+            h1: {
+              color: theme("colors.white"),
+            },
+            h2: {
+              color: theme("colors.white"),
+            },
+            h3: {
+              color: theme("colors.white"),
+            },
+            strong: {
+              color: theme("colors.white"),
+            },
+            code: {
+              color: theme("colors.cyan.200"),
+            },
+            blockquote: {
+              borderLeftColor: theme("colors.cyan.500"),
+              color: theme("colors.slate.100"),
+            },
+          },
+        },
+      }),
+    },
   },
-  plugins: [],
+  plugins: [typography],
 }
 


### PR DESCRIPTION
## Summary
- add the Tailwind typography plugin and tune light/dark prose presets for MarkdownSmith
- enhance MarkdownSmith preview theme styles so headings, links, and body copy render with rich typography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e440721e30832ab17e7e3a03c98ae6